### PR TITLE
Fix build single neuron + CI notifications

### DIFF
--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -565,7 +565,7 @@ jobs:
       # Send enhanced MS Teams notification for PRODUCTION
       - name: Send Teams Notification (Production)
         uses: skitionek/notify-microsoft-teams@v1.0.9
-        if: always() && inputs.env == 'production' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || failure())
+        if: always() && inputs.env == 'production' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         with:
           webhook_url: ${{ secrets.MS_TEAMS_NEW_WEBHOOK_URI }}
           raw: ${{ env.TEAMS_PAYLOAD }}
@@ -573,7 +573,7 @@ jobs:
       # Send enhanced MS Teams notification for STAGING
       - name: Send Teams Notification (Staging)
         uses: skitionek/notify-microsoft-teams@v1.0.9
-        if: always() && inputs.env == 'staging' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || failure())
+        if: always() && inputs.env == 'staging' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         with:
           webhook_url: ${{ secrets.MS_TEAMS_NEW_WEBHOOK_URI }}
           raw: ${{ env.TEAMS_PAYLOAD }}

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ feature:
 	$(MAKE) run-tests ENV=production ENV_URL=production TEST="tests/test_simulate_synaptome.py -vs --html=report.html --self-contained-html"
 
 feature-staging:
-	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_simulate_small_microcircuit.py --html=report.html --self-contained-html"
+	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_build_single_neuron.py --html=report.html --self-contained-html"
 
 # Workflow tests
 workflow:

--- a/locators/build_single_neuron_locators.py
+++ b/locators/build_single_neuron_locators.py
@@ -112,5 +112,5 @@ class BuildSingleNeuronLocators:
     COMPATIBILITY_SPINNER = (By.XPATH, "//div[contains(@class,'ant-spin') or contains(@class,'spinner')]")
     COMPATIBILITY_IN_PROGRESS = (By.XPATH, "//*[contains(text(),'compatibility check in progress') or contains(text(),'Compatibility check')]")
     COMPATIBILITY_SUCCESS = (By.XPATH, "//*[contains(text(),'compatible') and not(contains(text(),'not compatible'))]")
-    COMPATIBILITY_ERROR = (By.XPATH, "//*[contains(text(),'not compatible') or contains(text(),'Please select a different combination')]")
+    COMPATIBILITY_ERROR = (By.XPATH, "//*[contains(text(),'Incompatible') or contains(text(),'not compatible') or contains(text(),'different combination')]")
     COMPATIBILITY_SELECT_ANOTHER = (By.XPATH, "//button[.//div[contains(text(),'Select another model')] or contains(text(),'Select another model')]")

--- a/locators/build_single_neuron_locators.py
+++ b/locators/build_single_neuron_locators.py
@@ -80,7 +80,7 @@ class BuildSingleNeuronLocators:
     MODELING_SECTION = (By.XPATH, "//div[text()='Modeling']")
     
     # M-model and E-model table selectors (for when redirected to selection tables)
-    M_MODEL_TABLE = (By.ID, "data-table-with-filters")
+    M_MODEL_TABLE = (By.CSS_SELECTOR, "tbody.ant-table-tbody")
     M_MODEL_RADIO_BUTTON = (By.XPATH, "(//span[@class='ant-radio-inner'])[2]")
     FIRST_M_MODEL_RADIO = (By.XPATH, "//table[@id='data-table-with-filters']//tbody//tr[2]//input[@type='radio']")
     SECOND_M_MODEL_RADIO = (By.XPATH, "//table[@id='data-table-with-filters']//tbody//tr[3]//input[@type='radio']")
@@ -107,3 +107,10 @@ class BuildSingleNeuronLocators:
 
 
 
+
+    """Model compatibility check (appears under E-model tab after both models selected)."""
+    COMPATIBILITY_SPINNER = (By.XPATH, "//div[contains(@class,'ant-spin') or contains(@class,'spinner')]")
+    COMPATIBILITY_IN_PROGRESS = (By.XPATH, "//*[contains(text(),'compatibility check in progress') or contains(text(),'Compatibility check')]")
+    COMPATIBILITY_SUCCESS = (By.XPATH, "//*[contains(text(),'compatible') and not(contains(text(),'not compatible'))]")
+    COMPATIBILITY_ERROR = (By.XPATH, "//*[contains(text(),'not compatible') or contains(text(),'Please select a different combination')]")
+    COMPATIBILITY_SELECT_ANOTHER = (By.XPATH, "//button[.//div[contains(text(),'Select another model')] or contains(text(),'Select another model')]")

--- a/pages/build_single_neuron_page.py
+++ b/pages/build_single_neuron_page.py
@@ -481,7 +481,15 @@ class BuildSingleNeuronPage(ProjectHome):
         exclude_indices = exclude_indices or set()
         try:
             self.find_element(self.locators.M_MODEL_TABLE, timeout)
-            time.sleep(2)
+            # Wait for radio buttons to appear (table rows loading)
+            for wait_attempt in range(5):
+                time.sleep(2)
+                radios = self.browser.find_elements(
+                    By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//span[@class='ant-radio-inner']"
+                )
+                if radios:
+                    break
+                self.logger.info(f"Waiting for M-model radio buttons... attempt {wait_attempt + 1}")
             radios = self.browser.find_elements(
                 By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//span[@class='ant-radio-inner']"
             )
@@ -603,8 +611,8 @@ class BuildSingleNeuronPage(ProjectHome):
         """
         from selenium.webdriver.common.action_chains import ActionChains
 
-        tried_m = set()
-        last_m_idx = -1
+        tried_e = set()
+        last_e_idx = -1
 
         for attempt in range(max_retries):
             self.logger.info(f"Compatibility check attempt {attempt + 1}/{max_retries}")
@@ -632,31 +640,19 @@ class BuildSingleNeuronPage(ProjectHome):
                     self.logger.info("Clicked 'Select another model'")
                     time.sleep(3)
 
-                    # Go back to M-model tab and select a different one
-                    m_clicked = self.click_m_model_button()
-                    if not m_clicked:
-                        self.logger.warning("Could not click M-model button")
-                        return False
+                    # "Select another model" returns to E-model selection
+                    # M-model is already locked in, just pick a different E-model
+                    time.sleep(5)  # Wait for E-model table to reload
 
-                    tried_m.add(last_m_idx)
-                    new_m_idx = self.select_random_m_model(exclude_indices=tried_m)
-                    if new_m_idx == -1:
-                        self.logger.warning("No more M-models to try")
+                    tried_e.add(last_e_idx)
+                    new_e_idx = self.select_random_e_model(exclude_indices=tried_e)
+                    if new_e_idx == -1:
+                        self.logger.warning("No more E-models to try")
                         return False
-                    last_m_idx = new_m_idx
+                    last_e_idx = new_e_idx
+                    time.sleep(2)
 
-                    # Go back to E-model tab to trigger compatibility check
-                    e_clicked = self.click_e_model_button()
-                    if not e_clicked:
-                        self.logger.warning("Could not click E-model button")
-                        return False
-
-                    e_idx = self.select_random_e_model()
-                    if e_idx == -1:
-                        self.logger.warning("Could not select E-model after M-model change")
-                        return False
-
-                    self.logger.info("Selected different M-model + E-model, re-checking...")
+                    self.logger.info(f"Selected different E-model (index {new_e_idx}), re-checking...")
 
                 except TimeoutException:
                     self.logger.warning("'Select another model' button not found")

--- a/pages/build_single_neuron_page.py
+++ b/pages/build_single_neuron_page.py
@@ -186,6 +186,28 @@ class BuildSingleNeuronPage(ProjectHome):
         except Exception as e:
             print(f"❌ Error filling model name: {e}")
             return False
+
+    def fill_description(self, description="Automated test", timeout=10):
+        """Fill in the description field."""
+        try:
+            selectors = [
+                self.locators.DESCRIPTION_TEXTAREA,
+                self.locators.DESCRIPTION_TEXTAREA_ALT,
+            ]
+            for selector in selectors:
+                try:
+                    desc_input = self.element_to_be_clickable(selector, timeout)
+                    desc_input.clear()
+                    desc_input.send_keys(description)
+                    self.logger.info(f"Description filled: '{description}'")
+                    return True
+                except TimeoutException:
+                    continue
+            self.logger.warning("Description input not found")
+            return False
+        except Exception as e:
+            self.logger.warning(f"Error filling description: {e}")
+            return False
     
     def click_m_model_button(self, timeout=10):
         """Click the M-model selection button"""

--- a/pages/build_single_neuron_page.py
+++ b/pages/build_single_neuron_page.py
@@ -449,6 +449,200 @@ class BuildSingleNeuronPage(ProjectHome):
             print(f"❌ Error selecting E-model: {e}")
             return False
     
+
+
+    def select_random_m_model(self, exclude_indices=None, timeout=15):
+        """Select a random M-model from the table, optionally excluding already-tried indices.
+        Returns the index selected, or -1 if failed.
+        """
+        import random
+        exclude_indices = exclude_indices or set()
+        try:
+            self.find_element(self.locators.M_MODEL_TABLE, timeout)
+            time.sleep(2)
+            radios = self.browser.find_elements(
+                By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//span[@class='ant-radio-inner']"
+            )
+            if not radios:
+                radios = self.browser.find_elements(
+                    By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//input[@class='ant-radio-input']"
+                )
+            if not radios:
+                radios = self.browser.find_elements(
+                    By.CSS_SELECTOR, "span.ant-radio-inner"
+                )
+            if not radios:
+                self.logger.warning("No M-model radio buttons found")
+                return -1
+
+            available = [i for i in range(len(radios)) if i not in exclude_indices]
+            if not available:
+                self.logger.warning("All M-models already tried")
+                return -1
+
+            idx = random.choice(available)
+            radio = radios[idx]
+            self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", radio)
+            time.sleep(0.5)
+            self.browser.execute_script("arguments[0].click();", radio)
+            self.logger.info(f"Selected M-model at index {idx} (of {len(radios)})")
+            time.sleep(2)
+            return idx
+        except Exception as e:
+            self.logger.warning(f"Error selecting random M-model: {e}")
+            return -1
+
+    def select_random_e_model(self, exclude_indices=None, timeout=15):
+        """Select a random E-model from the table, optionally excluding already-tried indices.
+        Returns the index selected, or -1 if failed.
+        """
+        import random
+        exclude_indices = exclude_indices or set()
+        try:
+            self.find_element(self.locators.E_MODEL_TABLE, timeout)
+            self.wait_for_spinner_to_disappear()
+            time.sleep(2)
+            radios = self.browser.find_elements(
+                By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//span[@class='ant-radio-inner']"
+            )
+            if not radios:
+                radios = self.browser.find_elements(
+                    By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//input[@class='ant-radio-input']"
+                )
+            if not radios:
+                radios = self.browser.find_elements(By.XPATH, "//span[@class='ant-radio-inner']")
+            if not radios:
+                self.logger.warning("No E-model radio buttons found")
+                return -1
+
+            available = [i for i in range(len(radios)) if i not in exclude_indices]
+            if not available:
+                self.logger.warning("All E-models already tried")
+                return -1
+
+            idx = random.choice(available)
+            radio = radios[idx]
+            self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", radio)
+            time.sleep(0.5)
+            self.browser.execute_script("arguments[0].click();", radio)
+            self.logger.info(f"Selected E-model at index {idx} (of {len(radios)})")
+            time.sleep(2)
+            return idx
+        except Exception as e:
+            self.logger.warning(f"Error selecting random E-model: {e}")
+            return -1
+
+    def _run_compatibility_check(self, timeout=60):
+        """Run a single compatibility check cycle. Returns True if compatible, False if not."""
+        # Wait for spinner / "in progress" text
+        try:
+            self.find_element(self.locators.COMPATIBILITY_IN_PROGRESS, timeout=10)
+            self.logger.info("Model compatibility check in progress...")
+            # Wait for it to complete
+            try:
+                self.wait_for_element_to_disappear(self.locators.COMPATIBILITY_IN_PROGRESS, timeout=timeout)
+                self.logger.info("Compatibility check completed")
+            except Exception:
+                self.logger.warning(f"Compatibility check did not complete within {timeout}s")
+        except TimeoutException:
+            self.logger.info("No compatibility spinner detected, checking result directly")
+
+        time.sleep(2)
+
+        # Check for error
+        try:
+            error_el = self.browser.find_element(*self.locators.COMPATIBILITY_ERROR)
+            if error_el.is_displayed():
+                self.logger.warning(f"Compatibility FAILED: {error_el.text.strip()[:80]}")
+                return False
+        except Exception:
+            pass
+
+        # Check for success
+        try:
+            success_el = self.browser.find_element(*self.locators.COMPATIBILITY_SUCCESS)
+            if success_el.is_displayed():
+                self.logger.info("Compatibility check PASSED")
+                return True
+        except Exception:
+            pass
+
+        # Fallback: check build button
+        if self.is_build_model_button_enabled():
+            self.logger.info("Build button enabled — assuming compatible")
+            return True
+
+        return False
+
+    def wait_for_compatibility_check(self, max_retries=5, timeout=60):
+        """Wait for compatibility check. If incompatible, click 'Select another model'
+        and try a different E-model. Retries up to max_retries times.
+        Returns True if a compatible combination was found.
+        """
+        from selenium.webdriver.common.action_chains import ActionChains
+
+        tried_m = set()
+        last_m_idx = -1
+
+        for attempt in range(max_retries):
+            self.logger.info(f"Compatibility check attempt {attempt + 1}/{max_retries}")
+
+            compatible = self._run_compatibility_check(timeout=timeout)
+            if compatible:
+                self.logger.info(f"Compatible models found on attempt {attempt + 1}")
+                return True
+
+            # Not compatible — click "Select another model" and pick a different M-model
+            if attempt < max_retries - 1:
+                self.logger.info("Clicking 'Select another model' to try a different M-model...")
+                try:
+                    select_another = self.element_to_be_clickable(
+                        self.locators.COMPATIBILITY_SELECT_ANOTHER, timeout=10
+                    )
+                    self.browser.execute_script(
+                        "arguments[0].scrollIntoView({block: 'center'});", select_another
+                    )
+                    time.sleep(0.5)
+                    try:
+                        ActionChains(self.browser).move_to_element(select_another).click().perform()
+                    except Exception:
+                        self.browser.execute_script("arguments[0].click();", select_another)
+                    self.logger.info("Clicked 'Select another model'")
+                    time.sleep(3)
+
+                    # Go back to M-model tab and select a different one
+                    m_clicked = self.click_m_model_button()
+                    if not m_clicked:
+                        self.logger.warning("Could not click M-model button")
+                        return False
+
+                    tried_m.add(last_m_idx)
+                    new_m_idx = self.select_random_m_model(exclude_indices=tried_m)
+                    if new_m_idx == -1:
+                        self.logger.warning("No more M-models to try")
+                        return False
+                    last_m_idx = new_m_idx
+
+                    # Go back to E-model tab to trigger compatibility check
+                    e_clicked = self.click_e_model_button()
+                    if not e_clicked:
+                        self.logger.warning("Could not click E-model button")
+                        return False
+
+                    e_idx = self.select_random_e_model()
+                    if e_idx == -1:
+                        self.logger.warning("Could not select E-model after M-model change")
+                        return False
+
+                    self.logger.info("Selected different M-model + E-model, re-checking...")
+
+                except TimeoutException:
+                    self.logger.warning("'Select another model' button not found")
+                    return False
+
+        self.logger.warning(f"No compatible combination found after {max_retries} attempts")
+        return False
+
     def click_build_model_button(self, timeout=10):
         """Click the final Build model button"""
         try:

--- a/tests/test_build_single_neuron.py
+++ b/tests/test_build_single_neuron.py
@@ -64,6 +64,12 @@ class TestBuildSingleNeuron:
         name_filled = build_page.fill_model_name(model_name)
         assert name_filled, "Failed to fill model name"
         
+        desc_filled = build_page.fill_description("Automated test of single neuron build")
+        if desc_filled:
+            logger.info("Description filled")
+        else:
+            logger.warning("Description field not found, continuing...")
+        
         # Step 6: Select M-model
         print("\n📍 Step 6: Selecting M-model...")
         logger.info("Step 6: Selecting M-model")

--- a/tests/test_build_single_neuron.py
+++ b/tests/test_build_single_neuron.py
@@ -70,8 +70,8 @@ class TestBuildSingleNeuron:
         m_model_clicked = build_page.click_m_model_button()
         assert m_model_clicked, "Failed to click M-model button"
         
-        m_model_selected = build_page.select_first_m_model()
-        assert m_model_selected, "Failed to select M-model"
+        m_model_idx = build_page.select_random_m_model()
+        assert m_model_idx >= 0, "Failed to select M-model"
         
         # Step 7: Select E-model
         print("\n📍 Step 7: Selecting E-model...")
@@ -79,18 +79,25 @@ class TestBuildSingleNeuron:
         e_model_clicked = build_page.click_e_model_button()
         assert e_model_clicked, "Failed to click E-model button"
         
-        e_model_selected = build_page.select_first_e_model()
-        assert e_model_selected, "Failed to select E-model"
+        e_model_idx = build_page.select_random_e_model()
+        assert e_model_idx >= 0, "Failed to select E-model"
         
-        # Step 8: Build model
-        print("\n📍 Step 8: Building model...")
-        logger.info("Step 8: Building model")
+        # Step 8: Wait for compatibility check (retries with different E-model if incompatible)
+        print("\n📍 Step 8: Waiting for model compatibility check...")
+        logger.info("Step 8: Waiting for model compatibility check")
+        compatible = build_page.wait_for_compatibility_check(max_retries=5, timeout=60)
+        assert compatible, "No compatible M-model + E-model combination found after retries"
+        logger.info("Models are compatible")
+        
+        # Step 9: Build model
+        print("\n📍 Step 9: Building model...")
+        logger.info("Step 9: Building model")
         build_model_clicked = build_page.click_build_model_button()
         assert build_model_clicked, "Failed to click Build model button"
         
-        # Step 9: Wait for build completion or initiation
-        print("\n📍 Step 9: Waiting for build process...")
-        logger.info("Step 9: Waiting for build process")
+        # Step 10: Wait for build completion or initiation
+        print("\n📍 Step 10: Waiting for build process...")
+        logger.info("Step 10: Waiting for build process")
         build_completed = build_page.wait_for_build_completion()
         # Note: We don't assert this as the build process might take very long
         # and we just want to verify the workflow can be initiated


### PR DESCRIPTION
## Fix build single neuron + CI notifications

### Build single neuron
- Random M-model and E-model selection (not always first row)
- Model compatibility check after both models selected
- If incompatible: click "Select another model" → pick different E-model → retry (up to 5 attempts)
- Fix table/radio button locators (table ID removed, use ant-table selectors)
- Add description fill (Build button requires both name + description)
- Fix 'Incompatible' error detection (actual UI text vs old locator)

### CI
- Teams notifications only on scheduled + manual runs (no push/PR/feature branch noise)
