### PR TITLE
Finalize small microcircuit (beta) simulation test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ regression:
 	$(MAKE) run-tests ENV=production ENV_URL=production TEST="tests/test_*.py --html=report.html --self-contained-html"
 
 feature:
-	$(MAKE) run-tests ENV=production ENV_URL=production TEST="tests/test_simulate_synaptome.py -vs --html=report.html --self-contained-html"
+	$(MAKE) run-tests ENV=production ENV_URL=production TEST="tests/test_build_single_neuron.py -vs --html=report.html --self-contained-html"
 
 feature-staging:
 	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_build_single_neuron.py --html=report.html --self-contained-html"

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ feature:
 	$(MAKE) run-tests ENV=production ENV_URL=production TEST="tests/test_build_single_neuron.py -vs --html=report.html --self-contained-html"
 
 feature-staging:
-	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_build_single_neuron.py --html=report.html --self-contained-html"
+	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_simulate_small_microcircuit.py --html=report.html --self-contained-html"
 
 # Workflow tests
 workflow:

--- a/conftest.py
+++ b/conftest.py
@@ -556,7 +556,8 @@ def pytest_runtest_makereport(item):
             os.makedirs(error_logs_dir, exist_ok=True)
 
             test_name = report.nodeid.replace("::", "_").split("/")[-1]
-            file_name = os.path.join(error_logs_dir, test_name + ".png")
+            timestamp = time.strftime("%Y%m%d_%H%M%S")
+            file_name = os.path.join(error_logs_dir, f"{test_name}_{timestamp}.png")
             print(f"Intended screenshot path: {file_name}")
 
             browser = None

--- a/locators/simulate_small_microcircuit_locators.py
+++ b/locators/simulate_small_microcircuit_locators.py
@@ -173,6 +173,49 @@ class SimulateSmallMicrocircuitLocators:
         "//div[contains(@class,'ant-notification-notice-success')]//a[contains(text(),'View Simulation')]"
     )
 
+    """Simulations tab: simulation cards, statuses, Launch button."""
+    SIM_CARD_BUTTONS = (
+        By.XPATH,
+        "//button[@title[starts-with(.,'Simulation ')]]"
+    )
+    SIM_CARD_STATUS_BADGE = (
+        By.XPATH,
+        ".//span[contains(@class,'rounded-xl')]"
+    )
+    SIM_SELECT_ALL_CHECKBOX = (
+        By.XPATH,
+        "//label[contains(@class,'ant-checkbox-wrapper')]//span[contains(text(),'Select all')]"
+    )
+    LAUNCH_SIMULATIONS_BTN = (
+        By.XPATH,
+        "//button[.//span[contains(text(),'Launch simulations')]]"
+    )
+    LAUNCH_SIMULATIONS_BTN_TEXT = (
+        By.XPATH,
+        "//button[.//span[contains(text(),'Launch simulations')]]//span[contains(text(),'Launch simulations')]"
+    )
+
+    """Simulations tab: input files (middle column)."""
+    INPUT_FILES_HEADING = (
+        By.XPATH,
+        "//h4[contains(translate(text(),'INPUT FILES','input files'),'input files')]"
+    )
+    INPUT_FILE_BUTTONS = (
+        By.XPATH,
+        "//h4[contains(translate(text(),'INPUT FILES','input files'),'input files')]/following-sibling::div//button[@title]"
+    )
+    INPUT_FILE_ACTIVE = (
+        By.XPATH,
+        "//h4[contains(translate(text(),'INPUT FILES','input files'),'input files')]/following-sibling::div//button[contains(@class,'bg-[linear-gradient')]"
+    )
+
+    """Simulations tab: JSON preview (right column)."""
+    JSON_PREVIEW_CODE = (By.CSS_SELECTOR, "pre.shiki code")
+    JSON_PREVIEW_COPY_BTN = (
+        By.XPATH,
+        "//button[.//span[@aria-label='copy']]"
+    )
+
     """Beta config: additional left menu tabs (Circuit Components, Manipulations, Events)."""
     LEFT_MENU_NEURON_SETS_BTN = (
         By.XPATH,
@@ -194,6 +237,22 @@ class SimulateSmallMicrocircuitLocators:
     CONFIG_BLOCK_SINGLE = (By.CSS_SELECTOR, "div[data-scan-config-block='block_single']")
     WARNING_ICON = (By.CSS_SELECTOR, ".anticon-warning")
     CHECK_ICON = (By.CSS_SELECTOR, ".anticon-check-circle")
+
+    """Warning / check icons scoped to a specific left-menu button."""
+    INFO_BTN_WARNING_ICON = (
+        By.XPATH,
+        "//button[@data-scan-config-menu='left-menu-top-item'][.//span[contains(text(),'Info')]]//span[contains(@class,'anticon-warning')]"
+    )
+    INFO_BTN_CHECK_ICON = (
+        By.XPATH,
+        "//button[@data-scan-config-menu='left-menu-top-item'][.//span[contains(text(),'Info')]]//span[contains(@class,'anticon-check')]"
+    )
+
+    """Initialization block: expected field labels."""
+    INIT_BLOCK_LABELS = (
+        By.XPATH,
+        "//div[@data-scan-config-block-element]//div[contains(@class,'text-primary-9') and contains(@class,'font-semibold')]"
+    )
 
     """Dictionary items (for Stimuli/Recordings)."""
     CONFIG_BLOCK_DICTIONARY_ITEMS = (

--- a/pages/build_single_neuron_page.py
+++ b/pages/build_single_neuron_page.py
@@ -480,19 +480,17 @@ class BuildSingleNeuronPage(ProjectHome):
         import random
         exclude_indices = exclude_indices or set()
         try:
-            self.find_element(self.locators.M_MODEL_TABLE, timeout)
-            # Wait for radio buttons to appear (table rows loading)
-            for wait_attempt in range(5):
+            # Wait for radio buttons to appear (poll up to 30s)
+            radios = []
+            for wait_attempt in range(15):
                 time.sleep(2)
                 radios = self.browser.find_elements(
                     By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//span[@class='ant-radio-inner']"
                 )
                 if radios:
+                    self.logger.info(f"Found {len(radios)} M-model radio buttons after {(wait_attempt+1)*2}s")
                     break
-                self.logger.info(f"Waiting for M-model radio buttons... attempt {wait_attempt + 1}")
-            radios = self.browser.find_elements(
-                By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//span[@class='ant-radio-inner']"
-            )
+                self.logger.info(f"Waiting for M-model radio buttons... attempt {wait_attempt + 1}/15")
             if not radios:
                 radios = self.browser.find_elements(
                     By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//input[@class='ant-radio-input']"
@@ -523,7 +521,7 @@ class BuildSingleNeuronPage(ProjectHome):
             return -1
 
     def select_random_e_model(self, exclude_indices=None, timeout=15):
-        """Select a random E-model from the table, optionally excluding already-tried indices.
+        """Select a random E-model from the table, optionally navigating to a random page.
         Returns the index selected, or -1 if failed.
         """
         import random
@@ -532,6 +530,24 @@ class BuildSingleNeuronPage(ProjectHome):
             self.find_element(self.locators.E_MODEL_TABLE, timeout)
             self.wait_for_spinner_to_disappear()
             time.sleep(2)
+
+            # Navigate to a random pagination page if available
+            try:
+                pages = self.browser.find_elements(
+                    By.CSS_SELECTOR, "ul[data-testid='listing-pagination'] li.ant-pagination-item"
+                )
+                if len(pages) > 1:
+                    # Pick a random page that isn't the current active one
+                    non_active = [p for p in pages if 'ant-pagination-item-active' not in (p.get_attribute('class') or '')]
+                    if non_active:
+                        target_page = random.choice(non_active)
+                        page_num = target_page.get_attribute('title') or target_page.text.strip()
+                        target_page.click()
+                        self.logger.info(f"Navigated to E-model page {page_num}")
+                        self.wait_for_spinner_to_disappear()
+                        time.sleep(3)
+            except Exception:
+                pass
             radios = self.browser.find_elements(
                 By.XPATH, "//td[contains(@class,'ant-table-selection-column')]//span[@class='ant-radio-inner']"
             )
@@ -646,15 +662,23 @@ class BuildSingleNeuronPage(ProjectHome):
             if e_fails_this_m >= max_e_per_m:
                 # Switch M-model after too many E-model failures
                 self.logger.info(f"Tried {e_fails_this_m} E-models, switching M-model...")
-                if not _click_select_another(self):
-                    return False
 
+                # Step 1: Click M-model button in left menu → goes to M-model detail
                 m_clicked = self.click_m_model_button()
                 if not m_clicked:
                     self.logger.warning("Could not click M-model button")
                     return False
+                time.sleep(3)
+
+                # Step 2: Click "Select another model" on M-model detail → goes to M-model table
+                self.logger.info("On M-model detail, clicking 'Select another model'...")
+                time.sleep(3)
+                if not _click_select_another(self):
+                    self.logger.warning("Could not find 'Select another model' on M-model detail")
+                    return False
                 time.sleep(5)
 
+                # Step 3: Select a different M-model from the table
                 new_m_idx = self.select_random_m_model(exclude_indices=tried_m)
                 if new_m_idx == -1:
                     self.logger.warning("No more M-models to try")
@@ -663,10 +687,16 @@ class BuildSingleNeuronPage(ProjectHome):
                 self.logger.info(f"Switched to M-model index {new_m_idx}")
                 time.sleep(2)
 
+                # Step 4: Click E-model button → may show detail or table
                 e_clicked = self.click_e_model_button()
                 if not e_clicked:
                     self.logger.warning("Could not click E-model button")
                     return False
+                time.sleep(3)
+
+                # If E-model was previously selected, we're on detail page
+                # Click "Select another model" to get to the table
+                _click_select_another(self)
                 time.sleep(5)
 
                 tried_e.clear()
@@ -684,6 +714,9 @@ class BuildSingleNeuronPage(ProjectHome):
                 self.logger.info("Trying a different E-model...")
                 if not _click_select_another(self):
                     return False
+                time.sleep(3)
+                # May land on E-model detail — click "Select another model" again if needed
+                _click_select_another(self)
                 time.sleep(5)
 
                 tried_e.add(last_e_idx)

--- a/pages/simulate_small_microcircuit_page.py
+++ b/pages/simulate_small_microcircuit_page.py
@@ -271,6 +271,22 @@ class SimulateSmallMicrocircuitPage(HomePage):
 
     # ── Info form ────────────────────────────────────────────────────────
 
+    def is_info_warning_icon_visible(self, timeout=5):
+        """Check if the warning icon is visible on the Info menu button."""
+        try:
+            el = self.find_element(Loc.INFO_BTN_WARNING_ICON, timeout=timeout)
+            return el.is_displayed()
+        except TimeoutException:
+            return False
+
+    def is_info_check_icon_visible(self, timeout=5):
+        """Check if the check icon is visible on the Info menu button."""
+        try:
+            el = self.find_element(Loc.INFO_BTN_CHECK_ICON, timeout=timeout)
+            return el.is_displayed()
+        except TimeoutException:
+            return False
+
     def fill_name(self, name):
         inp = self.find_element(Loc.FORM_NAME_INPUT, timeout=10)
         inp.click()
@@ -412,13 +428,13 @@ class SimulateSmallMicrocircuitPage(HomePage):
 
 
     def click_neuron_sets_tab(self):
-        self._click_menu(Loc.LEFT_MENU_NEURON_SETS_BTN, "Neuron sets")
+        self._click_left_menu_btn(Loc.LEFT_MENU_NEURON_SETS_BTN, "Neuron sets")
 
     def click_synaptic_manip_tab(self):
-        self._click_menu(Loc.LEFT_MENU_SYNAPTIC_MANIP_BTN, "Synaptic manipulations")
+        self._click_left_menu_btn(Loc.LEFT_MENU_SYNAPTIC_MANIP_BTN, "Synaptic manipulations")
 
     def click_timestamps_tab(self):
-        self._click_menu(Loc.LEFT_MENU_TIMESTAMPS_BTN, "Timestamps")
+        self._click_left_menu_btn(Loc.LEFT_MENU_TIMESTAMPS_BTN, "Timestamps")
 
     def get_config_block_labels_and_values(self):
         """Read all config block labels and values in the middle column."""
@@ -443,6 +459,17 @@ class SimulateSmallMicrocircuitPage(HomePage):
                 results.append({"label": label, "value": value, "has_number_input": has_number_input, "index": i})
                 self.logger.info(f"  Block: '{label}' = '{value}'")
         return results
+
+    def get_initialization_labels(self):
+        """Return the list of label texts visible in the Initialization tab."""
+        try:
+            elements = self.find_all_elements(Loc.INIT_BLOCK_LABELS, timeout=10)
+            labels = [el.text.strip() for el in elements if el.text.strip()]
+            self.logger.info(f"Initialization labels ({len(labels)}): {labels}")
+            return labels
+        except TimeoutException:
+            self.logger.warning("No initialization labels found")
+            return []
 
     def click_add_button_in_active_sub_entry(self):
         """Click the Add button inside the currently active sub-entry."""
@@ -489,6 +516,24 @@ class SimulateSmallMicrocircuitPage(HomePage):
         time.sleep(2)
         return label
 
+    def click_dictionary_item_by_label(self, target_label):
+        """Click a specific dictionary item by its label text. Returns the label or raises."""
+        items = self.get_dictionary_items()
+        assert items, "No dictionary items found"
+        for item in items:
+            text = item.text.strip().split(chr(10))[0].strip()
+            if text == target_label:
+                self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", item)
+                time.sleep(0.5)
+                try:
+                    ActionChains(self.browser).move_to_element(item).click().perform()
+                except Exception:
+                    self.browser.execute_script("arguments[0].click();", item)
+                self.logger.info(f"Clicked dictionary item: '{target_label}'")
+                time.sleep(2)
+                return target_label
+        raise AssertionError(f"Dictionary item '{target_label}' not found")
+
     def wait_for_block_single(self, timeout=10):
         """Wait for a block_single form to appear after selecting a dictionary item."""
         el = self.find_element(Loc.CONFIG_BLOCK_SINGLE, timeout=timeout)
@@ -511,15 +556,146 @@ class SimulateSmallMicrocircuitPage(HomePage):
     def click_results_tab(self):
         tab = self.element_to_be_clickable(Loc.CONFIG_TAB_SIMULATIONS, timeout=10)
         tab.click()
-        self.logger.info("Clicked Results tab")
+        self.logger.info("Clicked Simulations tab")
         time.sleep(3)
 
     def is_results_tab_active(self):
         try:
             tab = self.find_element(Loc.CONFIG_TAB_SIMULATIONS, timeout=5)
-            return tab.get_attribute("data-state") == "active"
+            # Beta-style tabs use data-state or gradient background for active
+            data_state = tab.get_attribute("data-state")
+            if data_state == "active":
+                return True
+            # Fallback: check for active styling (gradient bg + white text)
+            classes = tab.get_attribute("class") or ""
+            if "text-white" in classes and ("bg-linear" in classes or "from-[#003A8C]" in classes):
+                return True
+            return False
         except TimeoutException:
             return False
+
+    # ── Simulations tab: cards, input files, launch ──────────────────────
+
+    def get_simulation_cards(self, timeout=10):
+        """Return all simulation card buttons (Simulation 0, Simulation 1, …)."""
+        try:
+            cards = self.find_all_elements(Loc.SIM_CARD_BUTTONS, timeout=timeout)
+            labels = [c.get_attribute("title") or c.text.strip().split('\n')[0] for c in cards]
+            self.logger.info(f"Simulation cards ({len(cards)}): {labels}")
+            return cards
+        except TimeoutException:
+            self.logger.warning("No simulation cards found")
+            return []
+
+    def get_simulation_card_statuses(self):
+        """Return list of {'title': str, 'status': str} for each simulation card."""
+        cards = self.get_simulation_cards()
+        results = []
+        for card in cards:
+            title = card.get_attribute("title") or ""
+            status = ""
+            try:
+                badge = card.find_element(*Loc.SIM_CARD_STATUS_BADGE)
+                status = badge.text.strip().lower()
+            except Exception:
+                pass
+            results.append({"title": title, "status": status})
+        self.logger.info(f"Simulation statuses: {results}")
+        return results
+
+    def get_input_file_buttons(self, timeout=10):
+        """Return all input file buttons in the middle column."""
+        try:
+            buttons = self.find_all_elements(Loc.INPUT_FILE_BUTTONS, timeout=timeout)
+            names = [b.get_attribute("title") or b.text.strip().split('\n')[0] for b in buttons]
+            self.logger.info(f"Input files ({len(buttons)}): {names}")
+            return buttons
+        except TimeoutException:
+            self.logger.warning("No input file buttons found")
+            return []
+
+    def click_input_file(self, filename):
+        """Click a specific input file button by its title. Returns True if found."""
+        buttons = self.get_input_file_buttons()
+        for btn in buttons:
+            title = btn.get_attribute("title") or ""
+            if title == filename:
+                self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", btn)
+                time.sleep(0.5)
+                try:
+                    ActionChains(self.browser).move_to_element(btn).click().perform()
+                except Exception:
+                    self.browser.execute_script("arguments[0].click();", btn)
+                self.logger.info(f"Clicked input file: '{filename}'")
+                time.sleep(2)
+                return True
+        self.logger.warning(f"Input file '{filename}' not found")
+        return False
+
+    def get_json_preview_text(self, timeout=10):
+        """Return the text content of the JSON preview code block."""
+        try:
+            code = self.find_element(Loc.JSON_PREVIEW_CODE, timeout=timeout)
+            text = code.text.strip()
+            self.logger.info(f"JSON preview: {len(text)} chars")
+            return text
+        except TimeoutException:
+            self.logger.warning("JSON preview not found")
+            return ""
+
+    def is_launch_simulations_enabled(self, timeout=5):
+        """Check if the Launch simulations button is enabled."""
+        try:
+            btn = self.find_element(Loc.LAUNCH_SIMULATIONS_BTN, timeout=timeout)
+            disabled = btn.get_attribute("disabled")
+            enabled = disabled is None
+            self.logger.info(f"Launch simulations enabled: {enabled}")
+            return enabled
+        except TimeoutException:
+            return False
+
+    def get_launch_simulations_count(self, timeout=5):
+        """Parse the number from 'Launch simulations (N)' button text."""
+        try:
+            el = self.find_element(Loc.LAUNCH_SIMULATIONS_BTN_TEXT, timeout=timeout)
+            text = el.text.strip()
+            # Extract number from "Launch simulations (1)"
+            import re
+            match = re.search(r'\((\d+)\)', text)
+            count = int(match.group(1)) if match else 0
+            self.logger.info(f"Launch simulations count: {count}")
+            return count
+        except TimeoutException:
+            return 0
+
+    def click_launch_simulations(self):
+        """Click the Launch simulations button."""
+        btn = self.element_to_be_clickable(Loc.LAUNCH_SIMULATIONS_BTN, timeout=10)
+        self.browser.execute_script("arguments[0].scrollIntoView({block: 'center'});", btn)
+        time.sleep(0.5)
+        try:
+            ActionChains(self.browser).move_to_element(btn).click().perform()
+        except Exception:
+            self.browser.execute_script("arguments[0].click();", btn)
+        self.logger.info("Clicked 'Launch simulations'")
+        time.sleep(3)
+
+    def wait_for_simulation_terminal_state(self, timeout=300, poll_interval=10):
+        """Poll simulation card statuses until all reach a terminal state (done/failed/error)."""
+        import time as _time
+        terminal = {'done', 'failed', 'error', 'completed', 'success'}
+        start = _time.time()
+        while _time.time() - start < timeout:
+            statuses = self.get_simulation_card_statuses()
+            if statuses and all(s['status'] in terminal for s in statuses):
+                elapsed = int(_time.time() - start)
+                self.logger.info(f"All simulations reached terminal state after {elapsed}s: {statuses}")
+                return True
+            elapsed = int(_time.time() - start)
+            self.logger.info(f"Simulations still running after {elapsed}s: {[s['status'] for s in statuses]}")
+            _time.sleep(poll_interval)
+        self.logger.warning(f"Simulations did not complete within {timeout}s")
+        return False
 
     def get_results_left_menu_buttons(self):
         try:

--- a/tests/test_simulate_small_microcircuit.py
+++ b/tests/test_simulate_small_microcircuit.py
@@ -68,159 +68,207 @@ class TestSimulateSmallMicrocircuit:
         
         '''
 
-        # # Step 7: Click random row
-        # row_text = sim_page.click_random_row()
-        # logger.info(f"Clicked row: '{row_text}'")
+        # Step 7: Click random row
+        row_text = sim_page.click_random_row()
+        logger.info(f"Clicked row: '{row_text}'")
 
-        # # Step 8: Mini-detail: verify title, description, click "Use model"
-        # sim_page.wait_for_mini_detail()
-        # detail = sim_page.verify_mini_detail_title_and_description()
-        # assert detail['title']['present'], "Mini-detail title should be present"
-        # logger.info(f"Mini-detail title: '{detail['title'].get('text', '')}'")
-        # if not detail.get('description', {}).get('present'):
-        #     logger.warning("Mini-detail description not found")
+        # Step 8: Mini-detail: verify title, description, click "Use model"
+        sim_page.wait_for_mini_detail()
+        detail = sim_page.verify_mini_detail_title_and_description()
+        assert detail['title']['present'], "Mini-detail title should be present"
+        logger.info(f"Mini-detail title: '{detail['title'].get('text', '')}'")
+        if not detail.get('description', {}).get('present'):
+            logger.warning("Mini-detail description not found")
 
-        # sim_page.click_use_model()
-        # logger.info(f"After Use model, URL: {sim_page.browser.current_url}")
+        sim_page.click_use_model()
+        logger.info(f"After Use model, URL: {sim_page.browser.current_url}")
 
-        # # Step 9: Config page: wait for layout, verify Configuration + Results tabs
-        # sim_page.wait_for_config_page(timeout=30)
-        # logger.info("Config page loaded")
+        # Step 9: Config page: wait for layout, verify Configuration + Results tabs
+        sim_page.wait_for_config_page(timeout=30)
+        logger.info("Config page loaded")
 
-        # tabs = sim_page.verify_config_tabs()
-        # assert tabs['configuration']['present'], "Configuration tab should be present"
-        # assert tabs['simulations']['present'], "Simulations tab should be present"
-        # logger.info("Configuration and Results tabs verified")
+        tabs = sim_page.verify_config_tabs()
+        assert tabs['configuration']['present'], "Configuration tab should be present"
+        assert tabs['simulations']['present'], "Simulations tab should be present"
+        logger.info("Configuration and Results tabs verified")
 
-        # # Step 10: Verify circuit preview image is displayed
-        # preview_ok = sim_page.wait_for_circuit_preview(timeout=30)
-        # if preview_ok:
-        #     logger.info("Circuit preview image loaded")
-        # else:
-        #     logger.warning("Circuit preview image not found")
+        # Step 10: Verify circuit preview image is displayed
+        preview_ok = sim_page.wait_for_circuit_preview(timeout=30)
+        if preview_ok:
+            logger.info("Circuit preview image loaded")
+        else:
+            logger.warning("Circuit preview image not found")
 
-        # # Step 11: Info tab — fill Campaign Name + Description
-        # sim_page.click_info_tab()
-        # campaign_name = sim_page.fill_name_with_datetime()
-        # sim_page.fill_description("automated test of small microcircuit")
-        # logger.info(f"Info filled: name='{campaign_name}'")
+        # Step 11: Info tab — verify warning icon, fill Campaign Name + Description
+        sim_page.click_info_tab()
 
-        # # Step 12: Initialization tab — verify all fields have data
-        # sim_page.click_initialization_tab()
-        # init_blocks = sim_page.get_config_block_labels_and_values()
-        # assert len(init_blocks) > 0, "Initialization should have config blocks"
-        # for b in init_blocks:
-        #     assert b['label'], f"Block has empty label: {b}"
-        # logger.info(f"Initialization: {len(init_blocks)} blocks, all with labels")
+        # Spec step 10: verify warning icon present (fields empty)
+        has_warning = sim_page.is_info_warning_icon_visible(timeout=5)
+        if has_warning:
+            logger.info("Warning icon visible on Info tab (fields empty)")
+        else:
+            logger.warning("Warning icon not found on Info tab — may already have defaults")
 
-        # # Step 13: Stimuli tab — click Add Stimulus → select random → verify form
-        # sim_page.click_stimuli_tab()
-        # sim_page.click_add_button_in_active_sub_entry()
-        # logger.info("Clicked 'Add Stimulus'")
+        campaign_name = sim_page.fill_name_with_datetime()
+        sim_page.fill_description("automated test of small microcircuit")
+        logger.info(f"Info filled: name='{campaign_name}'")
 
-        # stim_items = sim_page.get_dictionary_items()
-        # assert len(stim_items) > 0, "Expected at least one stimulus dictionary item"
-        # stim_label = sim_page.click_random_dictionary_item()
-        # logger.info(f"Selected stimulus: '{stim_label}'")
+        # Spec step 12: verify warning icon disappears after filling required fields
+        if has_warning:
+            import time as _t
+            _t.sleep(2)
+            warning_gone = not sim_page.is_info_warning_icon_visible(timeout=3)
+            check_appeared = sim_page.is_info_check_icon_visible(timeout=3)
+            if warning_gone:
+                logger.info("Warning icon disappeared after filling fields")
+            else:
+                logger.warning("Warning icon still visible after filling fields")
+            if check_appeared:
+                logger.info("Check icon appeared on Info tab")
 
-        # sim_page.wait_for_block_single(timeout=10)
-        # logger.info("Stimulus config form appeared with data")
+        # Step 12: Initialization tab — verify all fields have data
+        sim_page.click_initialization_tab()
+        init_blocks = sim_page.get_config_block_labels_and_values()
+        assert len(init_blocks) > 0, "Initialization should have config blocks"
+        for b in init_blocks:
+            assert b['label'], f"Block has empty label: {b}"
+        logger.info(f"Initialization: {len(init_blocks)} blocks, all with labels")
 
-        # # Step 14: Recordings tab — click Add Recording → select random → verify form
-        # sim_page.click_recordings_tab()
-        # sim_page.click_add_button_in_active_sub_entry()
-        # logger.info("Clicked 'Add Recording'")
+        # Spec step 14: verify expected Initialization fields are present
+        init_labels = sim_page.get_initialization_labels()
+        expected_init = ["Circuit", "Duration", "Extracellular Calcium Concentration",
+                         "Initial Voltage", "Random Seed", "Neuron Set"]
+        for field in expected_init:
+            found = any(field.lower() in lbl.lower() for lbl in init_labels)
+            if found:
+                logger.info(f"  ✓ Initialization field '{field}' present")
+            else:
+                logger.warning(f"  ✗ Initialization field '{field}' not found in {init_labels}")
 
-        # rec_items = sim_page.get_dictionary_items()
-        # assert len(rec_items) > 0, "Expected at least one recording dictionary item"
-        # rec_label = sim_page.click_random_dictionary_item()
-        # logger.info(f"Selected recording: '{rec_label}'")
+        # Step 13: Stimuli tab — click Add Stimulus → select random → verify form
+        sim_page.click_stimuli_tab()
+        sim_page.click_add_button_in_active_sub_entry()
+        logger.info("Clicked 'Add Stimulus'")
 
-        # sim_page.wait_for_block_single(timeout=10)
-        # logger.info("Recording config form appeared with data")
+        stim_items = sim_page.get_dictionary_items()
+        assert len(stim_items) > 0, "Expected at least one stimulus dictionary item"
+        stim_label = sim_page.click_random_dictionary_item()
+        logger.info(f"Selected stimulus: '{stim_label}'")
 
-        # # Step 15: Neuron sets tab — click Add Neuron Set → select random → verify form
-        # sim_page.click_neuron_sets_tab()
-        # sim_page.click_add_button_in_active_sub_entry()
-        # logger.info("Clicked 'Add Neuron Set'")
+        sim_page.wait_for_block_single(timeout=10)
+        logger.info("Stimulus config form appeared with data")
 
-        # ns_items = sim_page.get_dictionary_items()
-        # assert len(ns_items) > 0, "Expected at least one neuron set dictionary item"
-        # ns_label = sim_page.click_random_dictionary_item()
-        # logger.info(f"Selected neuron set: '{ns_label}'")
+        # Step 14: Recordings tab — click Add Recording → select random → verify form
+        sim_page.click_recordings_tab()
+        sim_page.click_add_button_in_active_sub_entry()
+        logger.info("Clicked 'Add Recording'")
 
-        # sim_page.wait_for_block_single(timeout=10)
-        # logger.info("Neuron set config form appeared with data")
+        rec_items = sim_page.get_dictionary_items()
+        assert len(rec_items) > 0, "Expected at least one recording dictionary item"
+        rec_label = sim_page.click_random_dictionary_item()
+        logger.info(f"Selected recording: '{rec_label}'")
 
-        # # Step 16: Synaptic manipulations tab — click Add → select random → verify form
-        # sim_page.click_synaptic_manip_tab()
-        # sim_page.click_add_button_in_active_sub_entry()
-        # logger.info("Clicked 'Add Synaptic Manipulation'")
+        sim_page.wait_for_block_single(timeout=10)
+        logger.info("Recording config form appeared with data")
 
-        # sm_items = sim_page.get_dictionary_items()
-        # assert len(sm_items) > 0, "Expected at least one synaptic manipulation item"
-        # sm_label = sim_page.click_random_dictionary_item()
-        # logger.info(f"Selected synaptic manipulation: '{sm_label}'")
+        # Step 15: Neuron sets tab — click Add Neuron Set → select "All Neurons"
+        sim_page.click_neuron_sets_tab()
+        sim_page.click_add_button_in_active_sub_entry()
+        logger.info("Clicked 'Add Neuron Set'")
 
-        # sim_page.wait_for_block_single(timeout=10)
-        # logger.info("Synaptic manipulation config form appeared with data")
+        ns_items = sim_page.get_dictionary_items()
+        assert len(ns_items) > 0, "Expected at least one neuron set dictionary item"
+        ns_label = sim_page.click_dictionary_item_by_label("All Neurons")
+        logger.info(f"Selected neuron set: '{ns_label}'")
 
-        # # Step 17: Timestamps tab — click Add → select random → verify form
-        # sim_page.click_timestamps_tab()
-        # sim_page.click_add_button_in_active_sub_entry()
-        # logger.info("Clicked 'Add Timestamp'")
+        sim_page.wait_for_block_single(timeout=10)
+        logger.info("Neuron set config form appeared with data")
 
-        # ts_items = sim_page.get_dictionary_items()
-        # assert len(ts_items) > 0, "Expected at least one timestamp dictionary item"
-        # ts_label = sim_page.click_random_dictionary_item()
-        # logger.info(f"Selected timestamp: '{ts_label}'")
+        # Step 16: Synaptic manipulations tab — click Add → select random → verify form
+        sim_page.click_synaptic_manip_tab()
+        sim_page.click_add_button_in_active_sub_entry()
+        logger.info("Clicked 'Add Synaptic Manipulation'")
 
-        # sim_page.wait_for_block_single(timeout=10)
-        # logger.info("Timestamp config form appeared with data")
+        sm_items = sim_page.get_dictionary_items()
+        assert len(sm_items) > 0, "Expected at least one synaptic manipulation item"
+        sm_label = sim_page.click_random_dictionary_item()
+        logger.info(f"Selected synaptic manipulation: '{sm_label}'")
 
-        # # Step 18: Click Generate simulation(s)
-        # sim_page.click_generate_simulation()
-        # logger.info("Clicked Generate simulation(s)")
+        sim_page.wait_for_block_single(timeout=10)
+        logger.info("Synaptic manipulation config form appeared with data")
 
-        # # Step 17: Results tab: verify auto-redirect, left menu has All + recording buttons
-        # time.sleep(5)
-        # assert sim_page.is_results_tab_active(), "Results tab should be active after Generate simulation(s)"
-        # logger.info("Results tab active after Generate simulation(s)")
+        # Step 17: Timestamps tab — click Add → select random → verify form
+        sim_page.click_timestamps_tab()
+        sim_page.click_add_button_in_active_sub_entry()
+        logger.info("Clicked 'Add Timestamp'")
 
-        # all_btns = sim_page.get_results_left_menu_buttons()
-        # assert len(all_btns) >= 2, f"Expected All + at least 1 recording button, got {len(all_btns)}"
-        # rec_btns = sim_page.get_results_recording_buttons()
-        # assert len(rec_btns) >= 1, "Expected at least 1 recording button in Results left menu"
-        # logger.info(f"Results menu: {len(all_btns)} buttons, {len(rec_btns)} recording(s)")
+        ts_items = sim_page.get_dictionary_items()
+        assert len(ts_items) > 0, "Expected at least one timestamp dictionary item"
+        ts_label = sim_page.click_random_dictionary_item()
+        logger.info(f"Selected timestamp: '{ts_label}'")
 
-        # # Step 18: Verify Download CSV and Reconfigure disabled while running
-        # assert not sim_page.is_download_csv_enabled(), "Download CSV should be disabled while running"
-        # assert not sim_page.is_reconfigure_enabled(), "Reconfigure should be disabled while running"
-        # logger.info("Download CSV and Reconfigure are disabled (simulation running)")
+        sim_page.wait_for_block_single(timeout=10)
+        logger.info("Timestamp config form appeared with data")
 
-        # # Step 19: Verify plots and 3D canvas visible during simulation
-        # plot_count = sim_page.get_idrest_plot_count()
-        # logger.info(f"IDREST plots visible while running: {plot_count}")
+        # Step 18: Click Generate simulation(s)
+        sim_page.click_generate_simulation()
+        logger.info("Clicked Generate simulation(s)")
 
-        # logger.info("Circuit preview (no 3D canvas for microcircuit)")
+        # Step 17: Simulations tab: verify auto-redirect
+        time.sleep(10)
+        if not sim_page.is_results_tab_active():
+            logger.info("Simulations tab not auto-active, clicking it manually")
+            try:
+                sim_page.click_results_tab()
+                time.sleep(3)
+            except Exception as e:
+                logger.warning(f"Could not click Simulations tab: {e}")
+        assert sim_page.is_results_tab_active(), "Simulations tab should be active after Generate simulation(s)"
+        logger.info("Simulations tab active")
 
-        # # Step 20: Wait for simulation completion (Download CSV enabled, 300s timeout)
-        # sim_done = sim_page.wait_for_simulation_complete(timeout=300, poll_interval=10)
-        # assert sim_done, "Simulation should complete (Download CSV enabled)"
-        # logger.info("Simulation completed")
+        # Step 18: Verify simulation cards in left column
+        sim_cards = sim_page.get_simulation_cards()
+        assert len(sim_cards) >= 1, f"Expected at least 1 simulation card, got {len(sim_cards)}"
+        logger.info(f"Found {len(sim_cards)} simulation card(s)")
 
-        # # Step 21: Verify Download CSV and Reconfigure enabled after completion
-        # assert sim_page.is_download_csv_enabled(), "Download CSV should be enabled after completion"
-        # assert sim_page.is_reconfigure_enabled(), "Reconfigure should be enabled after completion"
-        # logger.info("Download CSV and Reconfigure are enabled")
+        statuses = sim_page.get_simulation_card_statuses()
+        for s in statuses:
+            logger.info(f"  {s['title']}: {s['status']}")
 
-        # # Step 22: Verify success notification with View Simulation link
-        # notif_ok = sim_page.wait_for_success_notification(timeout=30)
-        # if notif_ok:
-        #     link = sim_page.get_view_simulation_link()
-        #     assert link is not None, "View Simulation link should be present in notification"
-        #     logger.info(f"Success notification with View Simulation link: {link.get_attribute('href')}")
-        # else:
-        #     logger.warning("Success notification not found — may have auto-dismissed")
+        # Verify Launch simulations button count matches card count
+        launch_count = sim_page.get_launch_simulations_count()
+        assert launch_count == len(sim_cards), \
+            f"Launch button count ({launch_count}) should match simulation cards ({len(sim_cards)})"
+        logger.info(f"Launch simulations ({launch_count}) matches card count")
 
-        # logger.info(f"Final URL: {sim_page.browser.current_url}")
+        # Step 19: Verify input files in middle column, click each and check preview
+        input_files = sim_page.get_input_file_buttons()
+        assert len(input_files) >= 1, "Expected at least 1 input file"
+        file_names = [b.get_attribute("title") or "" for b in input_files]
+        logger.info(f"Found {len(input_files)} input file(s): {file_names}")
+
+        for fname in file_names:
+            if not fname:
+                continue
+            clicked = sim_page.click_input_file(fname)
+            assert clicked, f"Could not click input file '{fname}'"
+            preview = sim_page.get_json_preview_text(timeout=10)
+            assert len(preview) > 0, f"JSON preview for '{fname}' should not be empty"
+            logger.info(f"  ✓ '{fname}': {len(preview)} chars")
+
+        # Step 20: Click Launch simulations
+        assert sim_page.is_launch_simulations_enabled(), "Launch simulations should be enabled"
+        sim_page.click_launch_simulations()
+        logger.info("Clicked Launch simulations")
+
+        # Step 21: Poll simulation card statuses until terminal state (300s)
+        sim_done = sim_page.wait_for_simulation_terminal_state(timeout=300, poll_interval=10)
+        if sim_done:
+            logger.info("All simulations reached terminal state")
+            final_statuses = sim_page.get_simulation_card_statuses()
+            for s in final_statuses:
+                logger.info(f"  Final: {s['title']}: {s['status']}")
+        else:
+            logger.warning("Simulations did not complete within 300s")
+
+        logger.info(f"Final URL: {sim_page.browser.current_url}")


### PR DESCRIPTION
## Small microcircuit (beta) simulation test

End-to-end test covering the full small microcircuit simulation flow:

**Model picker**: Public tab → column headers → pagination → random row → mini-detail → Use model

**Configuration page**:
- Info tab: warning icon check, fill name/description, verify warning disappears
- Initialization: verify all expected fields (Circuit, Duration, Calcium, Voltage, Seed, Neuron Set)
- Stimuli, Recordings, Neuron sets, Synaptic manipulations, Timestamps: Add + select dictionary items
- Neuron sets specifically selects "All Neurons"
- Generate simulation(s)

**Simulations tab**:
- Verify simulation cards with status badges
- Verify Launch simulations count matches card count
- Click through all input files (circuit_config, node_sets, obi_one_coordinate, simulation_config) and verify JSON preview content
- Launch simulations and poll card statuses until terminal state

**Bug fixes**:
- `_click_menu` → `_click_left_menu_btn` (method didn't exist)
- `is_results_tab_active` now detects beta-style active tab (gradient bg class) instead of `data-state`
