### PR TITLE
fix: network idle waits, Use model locator, emodel search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ feature:
 	$(MAKE) run-tests ENV=production ENV_URL=production TEST="tests/test_explore_page.py tests/test_ai_assistant_workflow.py -sv --html=report.html --self-contained-html"
 
 feature-staging:
-	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_explore_me_model.py -sv --html=report.html --self-contained-html"
+	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_simulate_me_beta.py tests/test_simulate_me_beta.py tests/test_simulate_mem.py  -sv --html=report.html --self-contained-html"
 
 # Workflow tests
 workflow:

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ feature:
 	$(MAKE) run-tests ENV=production ENV_URL=production TEST="tests/test_explore_page.py tests/test_ai_assistant_workflow.py -sv --html=report.html --self-contained-html"
 
 feature-staging:
-	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_simulate_me_beta.py tests/test_simulate_me_beta.py tests/test_simulate_mem.py  -sv --html=report.html --self-contained-html"
+	$(MAKE) run-tests ENV=staging ENV_URL=staging TEST="tests/test_explore_page.py tests/test_explore_emodel.py tests/test_explore_ndensity.py tests/test_explore_me_model.py -sv --html=report.html --self-contained-html"
 
 # Workflow tests
 workflow:

--- a/locators/simulate_ion_channel_locators.py
+++ b/locators/simulate_ion_channel_locators.py
@@ -37,7 +37,7 @@ class SimulateIonChannelLocators:
     MINI_DETAIL_DESCRIPTION = (By.CSS_SELECTOR, "#record-description")
     MINI_DETAIL_USE_MODEL_BTN = (
         By.CSS_SELECTOR,
-        "[data-testid='mini-viewer'] a[title='Start simulation']",
+        "[data-testid='mini-viewer'] [title='Start simulation']",
     )
 
     # ── Config page layout and top-level tabs ────────────────────────────

--- a/locators/simulate_me_beta_locators.py
+++ b/locators/simulate_me_beta_locators.py
@@ -66,7 +66,7 @@ class SimulateMeBetaLocators:
         "[data-testid='mini-viewer'] .text-primary-3.text-base.font-light"
     )
     MINI_DETAIL_VIEW_DETAILS_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] a[title='Go to details page']")
-    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] a[title='Start simulation']")
+    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] [title='Start simulation']")
     MINI_DETAIL_CLOSE_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] button .anticon-close")
 
     """Config page layout, top-level tabs (Configuration / Simulations),

--- a/locators/simulate_mem_locators.py
+++ b/locators/simulate_mem_locators.py
@@ -36,7 +36,7 @@ class SimulateMemLocators:
     """Mini-detail view after clicking a table row."""
     MINI_VIEWER = (By.CSS_SELECTOR, "[data-testid='mini-viewer']")
     MINI_DETAIL_TITLE = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] h1")
-    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] a[title='Start simulation']")
+    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] [title='Start simulation']")
 
     """Config page layout and top-level radix tabs (Configuration / Results)."""
     CONFIG_LAYOUT = (By.CSS_SELECTOR, "[data-testid='workflow-simulate-layout']")

--- a/locators/simulate_paired_neurons_locators.py
+++ b/locators/simulate_paired_neurons_locators.py
@@ -49,7 +49,7 @@ class SimulatePairedNeuronsLocators:
     MINI_DETAIL_DESCRIPTION = (By.CSS_SELECTOR, "#record-description")
     MINI_DETAIL_USE_MODEL_BTN = (
         By.CSS_SELECTOR,
-        "[data-testid='mini-viewer'] a[title='Start simulation']",
+        "[data-testid='mini-viewer'] [title='Start simulation']",
     )
 
     """Config page layout and top-level tabs."""

--- a/locators/simulate_small_microcircuit_locators.py
+++ b/locators/simulate_small_microcircuit_locators.py
@@ -46,7 +46,7 @@ class SimulateSmallMicrocircuitLocators:
     MINI_VIEWER = (By.CSS_SELECTOR, "[data-testid='mini-viewer']")
     MINI_DETAIL_TITLE = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] h1")
     MINI_DETAIL_DESCRIPTION = (By.CSS_SELECTOR, "#record-description")
-    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] a[title='Start simulation']")
+    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] [title='Start simulation']")
 
     """Config page layout and top-level tabs (Configuration / Results)."""
     CONFIG_LAYOUT = (By.CSS_SELECTOR, "button[data-scan-config-menu='left-menu-top-item']")

--- a/locators/simulate_synaptome_beta_locators.py
+++ b/locators/simulate_synaptome_beta_locators.py
@@ -49,7 +49,7 @@ class SimulateSynaptomeBetaLocators:
     MINI_DETAIL_DESCRIPTION = (By.CSS_SELECTOR, "#record-description")
     MINI_DETAIL_USE_MODEL_BTN = (
         By.CSS_SELECTOR,
-        "[data-testid='mini-viewer'] a[title='Start simulation']",
+        "[data-testid='mini-viewer'] [title='Start simulation']",
     )
 
     """Config page layout and top-level tabs."""

--- a/locators/simulate_synaptome_locators.py
+++ b/locators/simulate_synaptome_locators.py
@@ -50,7 +50,7 @@ class SimulateSynaptomeLocators:
     )
     MINI_DETAIL_CLOSE_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] button .anticon-close")
     MINI_DETAIL_VIEW_DETAILS_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] a[title='Go to details page']")
-    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] a[title='Start simulation']")
+    MINI_DETAIL_USE_MODEL_BTN = (By.CSS_SELECTOR, "[data-testid='mini-viewer'] [title='Start simulation']")
 
     """Config page layout and top-level radix tabs (Configuration / Results)."""
     CONFIG_LAYOUT = (By.CSS_SELECTOR, "[data-testid='workflow-simulate-layout']")

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -168,23 +168,27 @@ class CustomBasePage:
         Uses Performance API to detect when all resources have finished loading.
         Reduces database connection pool pressure by not navigating away while requests are in-flight.
         """
-        import time as perf_time
-        end_time = perf_time.time() + timeout
-        while perf_time.time() < end_time:
+        start = time.time()
+        end_time = start + timeout
+        while time.time() < end_time:
             pending = self.browser.execute_script("""
                 return window.performance.getEntriesByType('resource')
                     .filter(e => e.responseEnd === 0).length;
             """)
             if pending == 0:
-                perf_time.sleep(idle_time)
+                time.sleep(idle_time)
                 # Re-check after idle period
                 pending = self.browser.execute_script("""
                     return window.performance.getEntriesByType('resource')
                         .filter(e => e.responseEnd === 0).length;
                 """)
                 if pending == 0:
+                    elapsed = round(time.time() - start, 2)
+                    self.logger.info(f"Network idle after {elapsed}s")
                     return True
-            perf_time.sleep(0.5)
+            time.sleep(0.5)
+        elapsed = round(time.time() - start, 2)
+        self.logger.warning(f"Network NOT idle after {elapsed}s (timeout={timeout}s)")
         return False
 
     def wait_for_page_to_load(self, timeout=10, element_locator=None):

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -163,6 +163,30 @@ class CustomBasePage:
             f"Page did not reach ready state within {timeout} seconds"
         )
 
+    def wait_for_network_idle(self, timeout=10, idle_time=1):
+        """Wait until no network requests are pending.
+        Uses Performance API to detect when all resources have finished loading.
+        Reduces database connection pool pressure by not navigating away while requests are in-flight.
+        """
+        import time as perf_time
+        end_time = perf_time.time() + timeout
+        while perf_time.time() < end_time:
+            pending = self.browser.execute_script("""
+                return window.performance.getEntriesByType('resource')
+                    .filter(e => e.responseEnd === 0).length;
+            """)
+            if pending == 0:
+                perf_time.sleep(idle_time)
+                # Re-check after idle period
+                pending = self.browser.execute_script("""
+                    return window.performance.getEntriesByType('resource')
+                        .filter(e => e.responseEnd === 0).length;
+                """)
+                if pending == 0:
+                    return True
+            perf_time.sleep(0.5)
+        return False
+
     def wait_for_page_to_load(self, timeout=10, element_locator=None):
         local_wait = WebDriverWait(self.browser, timeout)
         local_wait.until(

--- a/tests/test_explore_emodel.py
+++ b/tests/test_explore_emodel.py
@@ -73,11 +73,7 @@ class TestExploreModelPage:
         input_placeholder = explore_emodel.input_placeholder(timeout=10)
         assert input_placeholder.is_displayed(), "Search input is not found"
         input_placeholder.click()
-        logger.info("Search input is clicked")
-
-        for char in searched_emodel:
-            input_placeholder.send_keys(char)
-            time.sleep(0.2)
+        input_placeholder.send_keys(searched_emodel)
         logger.info("Searching for 'cadpyr'")
         explore_emodel.wait_for_spinner_to_disappear(timeout=25)
 

--- a/tests/test_explore_emodel.py
+++ b/tests/test_explore_emodel.py
@@ -22,8 +22,8 @@ class TestExploreModelPage:
         print(f"DEBUG: Using lab_id={lab_id}, project_id={project_id}")
 
         explore_emodel.go_to_explore_emodel_page(lab_id, project_id)
+        explore_emodel.wait_for_network_idle(timeout=15)
         logger.info("Explore page is loaded")
-        time.sleep(5)  # Wait for brain region data to finish loading
 
         model_tab = explore_emodel.model_data_tab()
         assert model_tab.is_displayed(), "Model data tab is not displayed"

--- a/tests/test_explore_me_model.py
+++ b/tests/test_explore_me_model.py
@@ -39,8 +39,8 @@ class TestExploreMeModel:
 
         # ── Prerequisites: Navigate to ME-model list ─────────────────────
         me_model_page.go_to_explore_memodel_page(lab_id, project_id)
+        me_model_page.wait_for_network_idle(timeout=15)
         logger.info("ME-model list page loaded")
-        time.sleep(3)
 
         # Select a random species
         species = me_model_page.select_random_species()

--- a/tests/test_explore_ndensity.py
+++ b/tests/test_explore_ndensity.py
@@ -19,6 +19,7 @@ class TestExploreNeuronDensity:
         explore_ndensity = ExploreNeuronDensityPage(browser, wait, logger, base_url)
         explore_ndensity.go_to_explore_neuron_density_page(lab_id, project_id)
         explore_ndensity.wait_for_ndensity_tab(timeout=120)
+        explore_ndensity.wait_for_network_idle(timeout=15)
         logger.info(f"Neuron density tab is displayed, {browser.current_url}")
 
         cerebrum_brp = explore_ndensity.find_cerebrum_brp(timeout=30)

--- a/tests/test_explore_page.py
+++ b/tests/test_explore_page.py
@@ -22,6 +22,7 @@ class TestExplorePage:
         explore_page = ExplorePage(browser, wait, logger, base_url)
         print(f"DEBUG: Using lab_id={lab_id}, project_id={project_id}")
         explore_page.go_to_explore_page(lab_id, project_id)
+        explore_page.wait_for_network_idle(timeout=15)
         logger.info(f"Explore page is loaded, {browser.current_url}")
 
         # skip_onboarding = explore_page.skip_onboardin_btn(timeout=3)


### PR DESCRIPTION
## Summary
Reduces DB connection pool pressure, fixes locator for staging
deployment change, and fixes stale element on live search.

## Changes

### Network idle (DB pool pressure)
- Added `wait_for_network_idle()` to base_page.py — waits for all
  in-flight fetch requests to complete before proceeding
- Applied to explore_page, explore_emodel, explore_ndensity,
  explore_me_model after initial page load
- Replaces time.sleep(3/5) with proper network activity detection
- Logs elapsed time: "Network idle after X.Xs" or warns on timeout
- Prevents navigating away while 20-30 parallel API requests still
  hold DB connections (addresses QueuePool exhaustion)

### Use model button (staging deployment change)
- All simulate locators: changed `a[title='Start simulation']` to
  `[title='Start simulation']` — staging now uses `<button>` instead
  of `<a>` for this element

### Emodel search
- Send full search term at once instead of character-by-character
- Fixes stale element when live search re-renders input between keystrokes

## Testing
- Ran explore_page, explore_emodel, explore_ndensity, explore_me_model
  on staging — all passing with network idle logging confirmed
